### PR TITLE
reduce bundle size

### DIFF
--- a/src/v-click-outside-x.js
+++ b/src/v-click-outside-x.js
@@ -1,6 +1,4 @@
-import pkg from '../package.json';
-
-const version = pkg.version
+import { version } from '../package.json';
 
 /**
  * @typedef {import("../types/index.d.ts")} VClickOutsidePlugin


### PR DESCRIPTION
I noticed the import of the whole package json:

https://github.com/SergioCrisostomo/v-click-outside-x/blob/master/src/v-click-outside-x.js#L1

This adds an extra 4187 bytes to the bundle and makes no sense:

https://github.com/SergioCrisostomo/v-click-outside-x/blob/master/dist/v-click-outside-x.js#L159

The following is the comparison of bundle size before and after modification:

| filename                 | before (bytes) | after (bytes) | reduce ratio |
| :----------------------- | -------------: | ------------: | -----------: |
| v-click-outside-x.esm.js |          7,637 |         7,618 |        99.8% |
| v-click-outside-x.js     |         17,504 |        13,573 |        77.5% |
| v-click-outside-x.min.js |          7,780 |         4,253 |        54.7% |

The size of min.js has been reduced by half. Although ESM doesn't see much change here, But it will increases the size of projects that reference the library.


